### PR TITLE
Dolby: adapt equilizer screen composable for 15

### DIFF
--- a/dolby/src/co/aospa/dolby/xiaomi/geq/ui/EqualizerScreen.kt
+++ b/dolby/src/co/aospa/dolby/xiaomi/geq/ui/EqualizerScreen.kt
@@ -11,12 +11,12 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.android.settingslib.spa.framework.theme.SettingsDimension
-import com.android.settingslib.spa.framework.theme.SettingsTheme
 
 @Composable
 fun EqualizerScreen(
@@ -28,7 +28,7 @@ fun EqualizerScreen(
             .fillMaxSize()
             .padding(SettingsDimension.itemPadding)
             .then(modifier),
-        color = SettingsTheme.colorScheme.background
+        color = MaterialTheme.colorScheme.background
     ) {
         Column(
             verticalArrangement = Arrangement.Top,


### PR DESCRIPTION
hardware/oplus/dolby/src/co/aospa/dolby/oplus/geq/ui/EqualizerScreen.kt:31:17: error: function invocation 'SettingsTheme(...)' expected
        color = SettingsTheme.colorScheme.background
                ^
hardware/oplus/dolby/src/co/aospa/dolby/oplus/geq/ui/EqualizerScreen.kt:31:17: error: no value passed for parameter 'content'
        color = SettingsTheme.colorScheme.background
                ^
hardware/oplus/dolby/src/co/aospa/dolby/oplus/geq/ui/EqualizerScreen.kt:31:31: error: unresolved reference: colorScheme
        color = SettingsTheme.colorScheme.background